### PR TITLE
use nf-core configs to load hasta

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -19,6 +19,9 @@ params {
 
     platform='ILLUMINA'
 
+    // Utilize nf-core custom profiles 
+    custom_config_base         = "https://raw.githubusercontent.com/nf-core/configs/master"
+
     // Star reference directory path
     star_index="${reference_dir}/grch38_homo_sapiens_-gencode_pri-.fasta_star_genome_dir/"
 
@@ -48,6 +51,13 @@ process.shell = ['/bin/bash', '-euo', 'pipefail']
 
 // Load modules.config for DSL2 module specific options
 includeConfig 'conf/modules.config'
+
+// Load nf-core custom profiles from different Institutions
+try {
+    includeConfig "${params.custom_config_base}/nfcore_custom.config"
+} catch (Exception e) {
+    System.err.println("WARNING: Could not load nf-core/config profiles: ${params.custom_config_base}/nfcore_custom.config")
+}
 
 profiles {
     docker {


### PR DESCRIPTION
👋, this PR allows the use of nf-core institutional configs like so: `nextflow main.nf -profile singularity,hasta,dev_prio --samplesheet /path/to/samplesheet.csv --output /path/to/output`